### PR TITLE
Fixed bug in spacing utility

### DIFF
--- a/app/assets/stylesheets/utilities/_spacing.scss
+++ b/app/assets/stylesheets/utilities/_spacing.scss
@@ -27,12 +27,12 @@ $axes: (
   @return if($key == "none", 0, $value + $sizeUnit);
 }
 
-@function axisOrderedValues($axis, $value) {
-  @if $axis == "horizontal" {
-    @return 0 $value;
+@function axisPositions($axis) {
+  @if $axis == nth($axes, 1) {
+    @return join(nth($positions, 4), nth($positions, 2));
   }
-  @else if $axis == "vertical" {
-    @return $value 0;
+  @else if $axis == nth($axes, 2) {
+    @return join(nth($positions, 1), nth($positions, 3));
   }
 }
 
@@ -48,35 +48,16 @@ $axes: (
   }
 
   @each $axis in $axes {
+    $firstPos: nth(axisPositions($axis), 1);
+    $secondPos: nth(axisPositions($axis), 2);
+
     .#{$marginKey}#{$separator}#{$axis}#{$separator}#{$sizeKey} {
-      @if $sizeKey != "none" {
-        margin: axisOrderedValues($axis, sizeValue($sizeKey, $sizeValue));
-      }
-      @else {
-        @if $axis == "horizontal" {
-          margin-left: $sizeValue;
-          margin-right: $sizeValue;
-        }
-        @else if $axis == "vertical" {
-          margin-top: $sizeValue;
-          margin-bottom: $sizeValue;
-        }
-      }
+      margin-#{$firstPos}: sizeValue($sizeKey, $sizeValue);
+      margin-#{$secondPos}: sizeValue($sizeKey, $sizeValue);
     }
     .#{$paddingKey}#{$separator}#{$axis}#{$separator}#{$sizeKey} {
-      @if $sizeKey != "none" {
-        padding: axisOrderedValues($axis, sizeValue($sizeKey, $sizeValue));
-      }
-      @else {
-        @if $axis == "horizontal" {
-          padding-left: $sizeValue;
-          padding-right: $sizeValue;
-        }
-        @else if $axis == "vertical" {
-          padding-top: $sizeValue;
-          padding-bottom: $sizeValue;
-        }
-      }
+      padding-#{$firstPos}: sizeValue($sizeKey, $sizeValue);
+      padding-#{$secondPos}: sizeValue($sizeKey, $sizeValue);
     }
   }
 


### PR DESCRIPTION
### Fixed a bug in axis-based spacing utility.

#### Bug description:
Vertical & horizontal spacing was improperly implemented, that is why it reset other axis values.

##### Example:
``` css
.has-margin-vertical-sm {
  margin: 0.5rem 0;
}
```
The above snippet of code presents how `margin` was correctly set in the `vertical` axis. However, the `horizontal` one was unnecessarily turned into `0`.

#### Fixes:
After implementing this crucial fix, this CSS class looks like this:
``` css
.has-margin-vertical-sm {
  margin-top: 0.5rem;
  margin-bottom: 0.5rem;
}
```