### PR TITLE
Create ProfileCreator Service Object

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: %i(create)
+
+  def create
+    resource = User::Create.call(user: sign_up_params)
+    yield resource if block_given?
+    if resource.persisted?
+      handle_login(resource)
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
+
+  private
+
+  def handle_login(resource)
+    if resource.active_for_authentication?
+      set_flash_message! :notice, :signed_up
+      sign_up(resource_name, resource)
+      respond_with resource, location: after_sign_up_path_for(resource)
+    else
+      set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+      expire_data_after_sign_in!
+      respond_with resource, location: after_inactive_sign_up_path_for(resource)
+    end
+  end
+
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i(attribute))
+  end
+
+  def after_sign_up_path_for(resource)
+    super(resource)
+  end
+
+  def after_inactive_sign_up_path_for(resource)
+    super(resource)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,6 @@ class User
 
   has_one :profile, dependent: :destroy
 
-  after_create :create_profile
-
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -41,11 +39,5 @@ class User
 
   def username
     email.split("@")[0]
-  end
-
-  private
-
-  def create_profile
-    Profile.create!(user_id: id, name: username)
   end
 end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,5 @@
+class ApplicationService
+  def self.call(*args)
+    new(*args).call
+  end
+end

--- a/app/services/user/create.rb
+++ b/app/services/user/create.rb
@@ -1,0 +1,24 @@
+class User::Create < ApplicationService
+  def initialize(params)
+    @params = params[:user]
+  end
+
+  def call
+    self.user = build_user
+    create_profile if user.save
+    user
+  end
+
+  private
+
+  attr_accessor :user
+  attr_reader   :params
+
+  def create_profile
+    Profile.create!(user_id: user.id, name: user.username)
+  end
+
+  def build_user
+    User.new(params)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: "users/registrations" }
   root "landing#show"
   resources :profiles do
     resources :sections, except: %i(index show) do

--- a/spec/features/profile/profile_create_spec.rb
+++ b/spec/features/profile/profile_create_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.feature "Creating a profile" do
+  describe "after user registration" do
+    scenario "create his profile" do
+      visit new_user_registration_path
+      fill_in "user_email", with: "test@example.com"
+      fill_in "user_password", with: "password"
+      fill_in "user_password_confirmation", with: "password"
+      find("button[name='button']").click
+      within("#nav_menu") do
+        click_link("Profiles")
+      end
+      profile_container = find("div", class: "box")
+      expect(profile_container).to have_content("Test")
+    end
+  end
+end

--- a/spec/services/user/create_spec.rb
+++ b/spec/services/user/create_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe User::Create do
+  let(:sign_up_params) { attributes_for(:user) }
+  let(:user) { User.first }
+  let(:profile_user) { Profile.first.user }
+
+  subject { described_class }
+
+  it "creates user and associated profile" do
+    expect {
+      subject.call(user: sign_up_params)
+    }.to change {
+      User.count
+    }.from(0).to(1)
+    expect(profile_user).to eq(user)
+  end
+
+  it "should not create profile if user not saved" do
+    allow_any_instance_of(subject).to receive_message_chain("user.save") { false }
+    subject.call(user: sign_up_params)
+    expect(Profile.count).to eq(0)
+  end
+end


### PR DESCRIPTION
**Add ProfileCreator Service Object and ApplicatonService as a parent of all Service Objects**

- ApplicatonService is used for easier access to Service Objects. 
Instead of 
`ServiceObject.new(params).call`
We can use
`ServiceObject.call(params)`