### PR TITLE
Fixed Rubocop fail-level in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,4 +38,4 @@ jobs:
       # Check code styling using Rubocop
       - run:
           name: Check code styling using Rubocop
-          command: bundle exec rubocop --fail-level warning
+          command: bundle exec rubocop

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,16 +1,11 @@
 class ItemsController < ApplicationController
-  def new
-  end
+  def new; end
 
-  def create
-  end
+  def create; end
 
-  def edit
-  end
+  def edit; end
 
-  def update
-  end
+  def update; end
 
-  def destroy
-  end
+  def destroy; end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,11 +7,9 @@ class ProfilesController < ApplicationController
     @profiles = Profile.all
   end
 
-  def show
-  end
+  def show; end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @profile.update(profile_params)

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,16 +1,11 @@
 class SectionsController < ApplicationController
-  def new
-  end
+  def new; end
 
-  def create
-  end
+  def create; end
 
-  def edit
-  end
+  def edit; end
 
-  def update
-  end
+  def update; end
 
-  def destroy
-  end
+  def destroy; end
 end


### PR DESCRIPTION
Adjusted CircleCI config, so that Rubocop `fail-level` is set to `default`.