### PR TITLE
Add JavaScript to Bulma

### DIFF
--- a/app/assets/javascripts/bulma.coffee
+++ b/app/assets/javascripts/bulma.coffee
@@ -21,6 +21,10 @@ classes = {
   loading: "is-loading"
 }
 
+dataNames = {
+  target: "target"
+}
+
 hotkeys = {
   close: 27 # Esc key
 }
@@ -33,12 +37,15 @@ preventCloseSelector = elements.dropdowns + ", " + hooks.closeable
 getAll = (selector) ->
   document.querySelectorAll(selector)
 
-getTargetByData = (el, dataName) ->
-  data = el.getAttribute("data-#{dataName}")
-  document.getElementById(data)
+getData = (el, dataName) ->
+  el.getAttribute("data-#{dataName}") if el
+
+getTargetById = (el) ->
+  data = getData(el, dataNames.target)
+  document.getElementById(data) if data
 
 hasClass = (el, className) ->
-  el.classList.contains(className)
+  el.classList.contains(className) if el
 
 addClass = (el, className) ->
   el.classList.add(className) if el
@@ -48,34 +55,39 @@ removeClass = (el, className) ->
 
 removeClassFromAll = (selector, className) ->
   getAll(selector).forEach (el) ->
-    el.classList.remove(className)
+    removeClass(el, className)
 
 toggleClass = (el, className) ->
   el.classList.toggle(className) if el
 
 document.addEventListener "turbolinks:load", ->
   getAll(hooks.open).forEach (el) ->
-    el.addEventListener "click", ->
-      target = getTargetByData(el, "target")
+    el.addEventListener "click", (e) ->
+      e.stopPropagation();
+      target = el.closest(elements.toggleable)
+      target = getTargetById(el) if getData(el, dataNames.target)
       addClass(target, classes.active)
       addClass(elements.root, classes.clipped) if hasClass(target, "modal")
 
   getAll(hooks.close).forEach (el) ->
-    el.addEventListener "click", ->
+    el.addEventListener "click", (e) ->
+      e.stopPropagation();
       target = el.closest(elements.toggleable)
+      target = getTargetById(el) if getData(el, dataNames.target)
       removeClass(target, classes.active)
       removeClass(elements.root, classes.clipped) if hasClass(target, "modal")
 
   getAll(hooks.toggle).forEach (el) ->
     el.addEventListener "click", (e) ->
       e.stopPropagation();
-      target = getTargetByData(el, "target")
-      target = if target then target else el.closest(elements.toggleable)
+      target = el.closest(elements.toggleable)
+      target = getTargetById(el) if getData(el, dataNames.target)
       toggleClass(target, classes.active)
 
   getAll(hooks.delete).forEach (el) ->
     el.addEventListener "click", ->
       target = el.closest(elements.removable)
+      target = getTargetById(el) if getData(el, dataNames.target)
       target.remove() if target
 
   getAll(preventCloseSelector).forEach (el) ->
@@ -86,8 +98,8 @@ document.addEventListener "turbolinks:load", ->
     el.addEventListener "click", (e) ->
       e.stopPropagation();
       preventClose = false
-      target = getTargetByData(el, "target")
-      toggleClass(target, classes.active)
+      target = getTargetById(el) if getData(el, dataNames.target)
+      toggleClass(target, classes.active) if target
       toggleClass(el, classes.active)
 
   getAll(hooks.loading).forEach (el) ->

--- a/app/assets/javascripts/bulma.coffee
+++ b/app/assets/javascripts/bulma.coffee
@@ -1,0 +1,94 @@
+elements = {
+  root: document.documentElement,
+  toggleable: ".modal, .dropdown, .navbar-burger, .navbar-menu",
+  removable: ".notification, .message, .tag"
+}
+
+hooks = {
+  open: ".js-open",
+  close: ".js-close",
+  closeable: ".js-closeable"
+  toggle: ".js-toggle",
+  delete: ".js-delete",
+  burger: ".js-burger",
+  loading: ".js-disable-with-loading"
+}
+
+classes = {
+  active: "is-active",
+  clipped: "is-clipped",
+  loading: "is-loading"
+}
+
+hotkeys = {
+  close: 27 # Esc key
+}
+
+getAll = (selector) ->
+  document.querySelectorAll(selector)
+
+getTargetByData = (el, dataName) ->
+  data = el.getAttribute("data-#{dataName}")
+  document.getElementById(data)
+
+hasClass = (el, className) ->
+  el.classList.contains(className)
+
+addClass = (el, className) ->
+  el.classList.add(className) if el
+
+removeClass = (el, className) ->
+  el.classList.remove(className) if el
+
+removeClassFromAll = (selector, className) ->
+  getAll(selector).forEach (el) ->
+    el.classList.remove(className)
+
+toggleClass = (el, className) ->
+  el.classList.toggle(className) if el
+
+document.addEventListener "turbolinks:load", ->
+  getAll(hooks.open).forEach (el) ->
+    el.addEventListener "click", ->
+      target = getTargetByData(el, "target")
+      addClass(target, classes.active)
+      addClass(elements.root, classes.clipped) if hasClass(target, "modal")
+
+  getAll(hooks.close).forEach (el) ->
+    el.addEventListener "click", ->
+      target = el.closest(elements.toggleable)
+      removeClass(target, classes.active)
+      removeClass(elements.root, classes.clipped) if hasClass(target, "modal")
+
+  getAll(hooks.toggle).forEach (el) ->
+    el.addEventListener "click", (e) ->
+      e.stopPropagation();
+      target = getTargetByData(el, "target")
+      target = if target then target else el.closest(elements.toggleable)
+      toggleClass(target, classes.active)
+
+  getAll(hooks.delete).forEach (el) ->
+    el.addEventListener "click", ->
+      target = el.closest(elements.removable)
+      target.remove() if target
+
+  getAll(hooks.burger).forEach (el) ->
+    el.addEventListener "click", (e) ->
+      e.stopPropagation();
+      target = getTargetByData(el, "target")
+      toggleClass(target, classes.active)
+      toggleClass(el, classes.active)
+
+  getAll(hooks.loading).forEach (el) ->
+    el.addEventListener "click", ->
+      el.blur()
+      addClass(el, classes.loading)
+
+  document.addEventListener "keydown", (e) ->
+    if (e.keyCode == hotkeys.close)
+      selector = elements.toggleable + ", " + hooks.closeable
+      removeClassFromAll(selector, classes.active)
+
+  document.addEventListener "click", ->
+    selector = ".dropdown, " + hooks.closeable
+    removeClassFromAll(selector, classes.active)

--- a/app/assets/javascripts/bulma.coffee
+++ b/app/assets/javascripts/bulma.coffee
@@ -1,6 +1,7 @@
 elements = {
   root: document.documentElement,
-  toggleable: ".modal, .dropdown, .navbar-burger, .navbar-menu",
+  dropdowns: ".dropdown, .has-dropdown, .navbar-dropdown",
+  toggleable: ".modal, .dropdown, .has-dropdown, .navbar-burger, .navbar-menu",
   removable: ".notification, .message, .tag"
 }
 
@@ -23,6 +24,11 @@ classes = {
 hotkeys = {
   close: 27 # Esc key
 }
+
+# Prevent closeable elements from closing when we click on them
+preventClose = false
+# Selector of elements that should be prevented from closing
+preventCloseSelector = elements.dropdowns + ", " + hooks.closeable
 
 getAll = (selector) ->
   document.querySelectorAll(selector)
@@ -72,9 +78,14 @@ document.addEventListener "turbolinks:load", ->
       target = el.closest(elements.removable)
       target.remove() if target
 
+  getAll(preventCloseSelector).forEach (el) ->
+    el.addEventListener "click", ->
+      preventClose = true
+
   getAll(hooks.burger).forEach (el) ->
     el.addEventListener "click", (e) ->
       e.stopPropagation();
+      preventClose = false
       target = getTargetByData(el, "target")
       toggleClass(target, classes.active)
       toggleClass(el, classes.active)
@@ -90,5 +101,7 @@ document.addEventListener "turbolinks:load", ->
       removeClassFromAll(selector, classes.active)
 
   document.addEventListener "click", ->
-    selector = ".dropdown, " + hooks.closeable
-    removeClassFromAll(selector, classes.active)
+    if preventClose
+      preventClose = false
+      return
+    removeClassFromAll(preventCloseSelector, classes.active)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 
 @import "layout/navbar";
 @import "layout/footer";
+@import "layout/notifications";
 
 @import "components/brand";
 @import "components/box";

--- a/app/assets/stylesheets/layout/_footer.scss
+++ b/app/assets/stylesheets/layout/_footer.scss
@@ -1,9 +1,9 @@
 .footer {
-  padding: 3rem 1.5rem;
+  padding: 3rem 2rem;
 
   &-brand {
     margin: 0 1.5rem 0 0;
-    
+
     @include until($desktop) {
       margin: 0 0 1.5rem 0;
       text-align: center;

--- a/app/assets/stylesheets/layout/_navbar.scss
+++ b/app/assets/stylesheets/layout/_navbar.scss
@@ -1,9 +1,63 @@
 .navbar {
-  &-brand {
-    @include from($desktop) {
-      margin-right: 0.5rem;
-      padding-right: 0.5rem;
-      border-right: 1px solid $dark;
+  &.is-spaced {
+    padding: 1rem 2rem;
+
+    @include until($desktop) {
+      padding: 1rem;
+    }
+  }
+}
+
+.navbar-brand {
+  @include from($desktop) {
+    margin-right: 0.5rem;
+    padding-right: 0.5rem;
+    border-right: 1px solid $dark;
+  }
+}
+
+.navbar-menu {
+  @include until($desktop) {
+    margin: 1rem 0.5rem;
+    border-radius: $navbar-menu-radius;
+  }
+}
+
+.navbar-dropdown {
+  min-width: $navbar-dropdown-width;
+
+  @include until($desktop) {
+    display: none;
+    min-width: auto;
+    margin: 0.5rem 1rem;
+    border: 1px solid $grey-lighter;
+    border-radius: $navbar-menu-radius;
+  }
+}
+
+.navbar-item {
+  &.has-dropdown {
+    &.is-active {
+      .navbar-dropdown {
+        @include until($desktop) {
+          display: block;
+        }
+      }
+    }
+  }
+}
+
+.navbar-link {
+  &:not(.is-arrowless) {
+    &::after {
+      display: block;
+      border-color: $grey;
+    }
+
+    &:hover {
+      &::after {
+        border-color: $link;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/layout/_notifications.scss
+++ b/app/assets/stylesheets/layout/_notifications.scss
@@ -1,0 +1,7 @@
+.notifications {
+  padding: 0 1.5rem;
+
+  .notification:first-child {
+    margin-top: 3rem;
+  }
+}

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -8,6 +8,9 @@ $family-sans-serif: "Open Sans", "Roboto", "Helvetica", sans-serif;
 
 // Custom variables
 
+$navbar-menu-radius: $radius-large;
+$navbar-dropdown-width: 200px;
+
 $narrow-width: 600px;
 
 $shadow-sm: 0.5rem rgba($black, 0.075);

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -24,7 +24,7 @@
                   %i.fa.fa-lock
             .field
               .control
-                = f.submit "Change my password", class: "button is-primary is-medium is-fullwidth"
+                = f.button "Change my password", class: "button is-primary is-medium is-fullwidth js-disable-with-loading"
           .columns
             .column.links
               = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -15,7 +15,7 @@
                   %i.fa.fa-envelope
             .field
               .control
-                = f.submit "Reset password", class: "button is-primary is-medium is-fullwidth"
+                = f.button "Reset password", class: "button is-primary is-medium is-fullwidth js-disable-with-loading"
           .columns
             .column.links
               = render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -28,7 +28,7 @@
                   %i.fa.fa-lock
             .field
               .control
-                = f.submit "Sign up", class: "button is-primary is-medium is-fullwidth"
+                = f.button "Sign up", class: "button is-primary is-medium is-fullwidth js-disable-with-loading"
           .columns
             .column.links
               = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -22,7 +22,7 @@
               = f.label :remember_me, class: "checkbox"
             .field
               .control
-                = f.submit "Sign in", class: "button is-primary is-medium is-fullwidth"
+                = f.button "Sign in", class: "button is-primary is-medium is-fullwidth js-disable-with-loading"
           .columns
             .column.links
               = render "devise/shared/links"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,7 +15,7 @@
       = render "shared/navbar"
       .site-content
         - if flash.any?
-          .section.has-padding-bottom-none
+          .notifications
             .container
               = render "shared/flash_messages"
         = render "shared/main"

--- a/app/views/profiles/_form.html.haml
+++ b/app/views/profiles/_form.html.haml
@@ -22,7 +22,7 @@
                   .fa.fa-plus-circle
   .field
     .control
-      = f.submit "Update profile", class: "button is-primary is-medium is-fullwidth"
+      = f.button "Update profile", class: "button is-primary is-medium is-fullwidth js-disable-with-loading"
 .columns
   .column.is-narrow.actions
     = link_to "Back", profile_path(@profile), class: "button is-danger is-outlined"

--- a/app/views/shared/_flash_messages.html.haml
+++ b/app/views/shared/_flash_messages.html.haml
@@ -1,6 +1,6 @@
 - flash.each do |key, value|
   %div{class: "notification #{flash_class(key)}"}
-    %button.delete
+    %button.delete.js-delete
     - if value.class != Array
       %p= value
     - else

--- a/app/views/shared/_navbar.html.haml
+++ b/app/views/shared/_navbar.html.haml
@@ -2,7 +2,7 @@
   .container
     .navbar-brand
       = link_to "Portfolio", root_path, class: "navbar-item brand-logo has-background-transparent"
-      .navbar-burger.burger{"data-target": "navMenu"}
+      .navbar-burger.js-burger{"data-target": "navMenu"}
         %span
         %span
         %span
@@ -14,7 +14,7 @@
           .field.is-grouped.is-grouped-multiline
             - if user_signed_in?
               %p.control
-                = link_to "Sign out", destroy_user_session_path, method: :delete, class: "button is-danger is-outlined is-rounded"
+                = link_to "Sign out", destroy_user_session_path, method: :delete, class: "button is-danger is-outlined is-rounded js-disable-with-loading"
             - else
               %p.control
                 = link_to "Sign in", new_user_session_path, class: "button is-info is-outlined is-rounded"

--- a/app/views/shared/_navbar.html.haml
+++ b/app/views/shared/_navbar.html.haml
@@ -10,13 +10,25 @@
       .navbar-start
         = render "shared/nav_items", classes: "navbar-item"
       .navbar-end
-        .navbar-item
-          .field.is-grouped.is-grouped-multiline
-            - if user_signed_in?
-              %p.control
-                = link_to "Sign out", destroy_user_session_path, method: :delete, class: "button is-danger is-outlined is-rounded js-disable-with-loading"
-            - else
-              %p.control
-                = link_to "Sign in", new_user_session_path, class: "button is-info is-outlined is-rounded"
-              %p.control
-                = link_to "Sign up", new_user_registration_path, class: "button is-primary is-outlined is-rounded"
+        - if user_signed_in?
+          .navbar-item.has-dropdown
+            .navbar-link.is-unselectable.js-toggle
+              %span.icon.has-margin-right-xxs
+                .fa.fa-user-circle-o
+              %span= current_user.username.upcase_first
+            .navbar-dropdown.is-right
+              .dropdown-item
+                %p.has-text-weight-bold Signed in as
+                %p= "#{current_user.username.upcase_first} (#{current_user.email})"
+              %hr.dropdown-divider
+              - if current_user.profile.present?
+                = link_to "Your profile", profile_path(current_user.profile), class: "dropdown-item"
+              %hr.dropdown-divider
+              .dropdown-item
+                .buttons
+                  = link_to "Sign out", destroy_user_session_path, method: :delete, class: "button is-danger is-outlined is-rounded js-disable-with-loading"
+        - else
+          .navbar-item
+            .buttons.is-centered
+              = link_to "Sign in", new_user_session_path, class: "button is-info is-outlined is-rounded"
+              = link_to "Sign up", new_user_registration_path, class: "button is-primary is-outlined is-rounded"


### PR DESCRIPTION
### Implemented JavaScript hooks to Bulma

#### Bulma elements:
* Considered as dropdowns: dropdown, navbar-dropdown
* Considered as toggleable: modal, dropdown, navbar-burger, navbar-menu
* Considered as removable: notification, message, tag

However, almost every element of the website can be tied using predefined JavaScript hooks.
You simply add an appropriate CSS class (JS hook) to the desired element.

#### Predefined hooks:
* js-open
* js-close
* js-closeable
* js-toggle
* js-delete
* js-burger
* js-disable-with-loading

If you would like to override the default target, simply specify the element that you want to interact with using `data-target` attribute.